### PR TITLE
Change Nether_brick_item in Nether brick factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4472,8 +4472,8 @@ production_recipes:
         amount: 512
     outputs:
       Nether bricks:
-        material: NETHER_BRICK_ITEM
-        amount: 1024
+        material: NETHER_BRICK
+        amount: 256
   Bake_clay_blocks:
     name: Bake Clay Blocks
     production_time: 32


### PR DESCRIPTION
Change Nether_brick_item in Nether brick factory into Nether_brick and then I div by 4 the output.

Nether_brick_item is the item and Nether_brick is the block.

After making 150 stacks of blocks I feel the pain.
