### PR TITLE
Restore recipe balance for fish from 1.6.x to 1.7.x fishing mechanic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5450,7 +5450,7 @@ production_recipes:
     outputs:
       Cooked Fish:
         material: COOKED_FISH
-        amount: 256
+        amount: 512
   Dye_Pink_Wool_Black:
     name: Dye Pink Wool Black
     inputs:


### PR DESCRIPTION
Per ttk2 comment: http://www.reddit.com/r/Civcraft/comments/2ravi7/changelog_for_20150104_break_all_the_things/cneighq

Diamond cauldron recipes were originally balanced against 1.6.x mechanics which only returned "Fish" when fishing. Now their is a significant chance of getting other items in 1.7. We never re-balanced the factories to account for this. Doubling output of cooked fish in the grill factory is a trivial fix to this.