### PR TITLE
Fixed the check for citadel access

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,5 +2,5 @@ name: FactoryMod
 main: com.github.igotyou.FactoryMod.FactoryModPlugin
 author: igotyou
 
-version: 1.3.2
+version: 1.3.3
 depend: [NameLayer, Citadel]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.igotyou</groupId>
   <artifactId>FactoryMod</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.2-${build.number}</version>
+  <version>1.3.3-${build.number}</version>
   <name>FactoryMod</name>
   <url>https://github.com/Civcraft/FactoryMod</url>
    

--- a/src/com/github/igotyou/FactoryMod/Factorys/NetherFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/NetherFactory.java
@@ -162,9 +162,8 @@ public class NetherFactory extends BaseFactory
 	public List<InteractionResponse> getTeleportationBlockResponse(final Player player, Location clickedBlock)
 	{
 		List<InteractionResponse> responses=new ArrayList<InteractionResponse>();
-		//does the player have acsess to the nether factory via ciatdel?
-		if ((!FactoryModPlugin.CITADEL_ENABLED || (FactoryModPlugin.CITADEL_ENABLED && rm.getReinforcement(factoryLocation) != null)) || 
-				(((PlayerReinforcement) rm.getReinforcement(factoryLocation)).isAccessible(player)))
+		//does the player have access to the nether factory via Citadel?
+		if (!FactoryModPlugin.CITADEL_ENABLED || rm.getReinforcement(factoryLocation) == null || (((PlayerReinforcement) rm.getReinforcement(factoryLocation)).isAccessible(player)))
 		{
 			if (mode == NetherOperationMode.TELEPORT)
 			{
@@ -241,7 +240,7 @@ public class NetherFactory extends BaseFactory
 		}
 		else
 		{
-			//is the player potentialy holding a security note/ticket?
+			//is the player potentially holding a security note/ticket?
 			ItemStack itemInHand = player.getItemInHand();
 			if (itemInHand.getType() == Material.PAPER)
 			{


### PR DESCRIPTION
Originally the conditions for teleporting where as follows: 
    !citadel_enabled or (citadel_enabled and reinforcement != null) or reinforcement.isAccessible
this is the same as
    (!citadel_enabled or citadel_enabled) and (!citadel_enabled or reinforcement!=null) or reinforcement.isAccessible
(!citadel_enabled or citadel_enabled) is obviously true so this becomes
   !citadel_enabled or reinforcement != null or reinforcement.isAccessible

the problem should be obvious here. If reinforcement is ever not null this will go forward regardless of the ability of the player to access the factory.

What I believe was intended was to check if the reinforcement was null and if so just to allow anyone through. To this end I've changed the condition to:
   !citadel_enabled or reinforcement == null or reinforcement.isAccessible

I'm not sure why we were getting some reports of it working properly. Possibly people were just misinformed. This should be a very straight forward change, but I'll try to look into seeing if it works after I've finished with my school work which may take a while 

