### PR TITLE
Printing Press better reporting first pass; adding core and edge case logging.

### DIFF
--- a/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
@@ -3,6 +3,9 @@ package com.github.igotyou.FactoryMod.Factorys;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -33,6 +36,8 @@ public abstract class BaseFactory extends FactoryObject implements Factory {
 	protected int currentEnergyTimer = 0;//Time since last energy consumption(if there's no lag, it's in seconds)
 	protected double currentRepair;
 	protected long timeDisrepair;//The time at which the factory went into disrepair
+
+	private Logger log = Logger.getLogger(BaseFactory.class.getName());
 
 	public BaseFactory(Location factoryLocation,
 			Location factoryInventoryLocation, Location factoryPowerSource,
@@ -177,10 +182,13 @@ public abstract class BaseFactory extends FactoryObject implements Factory {
 						//[Requires one of the following: Amount Name, Amount Name.]
 						
 						ItemList<NamedItemStack> needAll=new ItemList<NamedItemStack>();
-						needAll.addAll(getAllInputs().getDifference(getInventory()));
+						ItemList<NamedItemStack> allInputs = getAllInputs();
+						needAll.addAll(allInputs.getDifference(getInventory()));
 						if(!needAll.isEmpty())
 						{
 							response.add(new InteractionResponse(InteractionResult.FAILURE,"You need all of the following: "+needAll.toString()+"."));
+						} else if (allInputs == null || allInputs.isEmpty()) {
+							log.log(Level.WARNING, "getAllInputs() returned null or empty; recipe is returning no expectation of input!");
 						}
 						return response;
 					}


### PR DESCRIPTION
Adding logging to Printing Press and Base Factory. 

I added an edge case to BaseFactory that might never execute; it may not be necessary but certainly causes no harm.

I also added probably too-liberal logging to PrintingPress; worst case will just be a bit spammy on the logs, but since it's using its own Logger can be easily filtered/grep'd. 

Compiles fine locally.