### PR TITLE
Addressing Class Cast exception in stack trace

### DIFF
--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -541,7 +541,12 @@ public class PrintingPress extends BaseFactory {
 					if (title == null) {
 						title = "";
 					}
-					List<String> pages = new ArrayList<String>((int)(bookData.hasPages() ? bookData.getPages() : 0));
+					List<String> pages = new ArrayList<String>();
+					if (bookData.hasPages()) {
+						pages.addAll(bookData.getPages());
+					} else {
+						log.info("getPlateResult(): Book found has no pages.");
+					}
 					
 					NamedItemStack plates = new NamedItemStack(Material.WRITTEN_BOOK, 1, (short) 0, "plate");
 					BookMeta plateMeta = (BookMeta) plates.getItemMeta();


### PR DESCRIPTION
In https://github.com/Civcraft/FactoryMod/commit/dd887c22effc392d1bb27786c4556a781e368b19 there was an incorrect BookMeta method use (casting the actual pages as an int).

Altered to be the correct check (empty array unless there are pages, if there are, add all the pages.)

I'm working on a second commit to address the 0 page book bug also identified in the logs erocs posted.