### PR TITLE
Minor fix to PrintUtils & a rogue typo

### DIFF
--- a/src/com/github/igotyou/FactoryMod/managers/FactoryModManager.java
+++ b/src/com/github/igotyou/FactoryMod/managers/FactoryModManager.java
@@ -45,7 +45,7 @@ public class FactoryModManager
 	 */
 	public FactoryModManager(FactoryModPlugin plugin)
 	{
-		FactoryModPlugin.sendConsoleMessage("Initiaiting FactoryMod Managers.");
+		FactoryModPlugin.sendConsoleMessage("Initiating FactoryMod Managers.");
 		this.plugin = plugin;
 		FactoryModManager.factoryMan = this;
 		

--- a/src/com/github/igotyou/FactoryMod/utility/StringUtils.java
+++ b/src/com/github/igotyou/FactoryMod/utility/StringUtils.java
@@ -11,7 +11,7 @@ public class StringUtils {
 	 * Formats a Location's coordinates as "world (x y z)"
 	 */
 	public static String formatCoords(Location loc) {
-		return String.format("%s (%d %d %d)", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockX(), loc.getBlockZ());
+		return String.format("%s (%d %d %d)", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
 	}
 	
 	public static List<String> splitLines(String paragraph, int lineLength) {


### PR DESCRIPTION
Probably more I should be looking at, but fixed the PrintUtils typo outputting X,X,Z instead of X,Y,Z on locations.