### PR TITLE
Diamond Cauldron Recipe 3 Switch/Balance

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4163,7 +4163,7 @@ production_recipes:
       Ink:
         material: 'INK_SACK'
         durability: 0
-        amount: 16
+        amount: 2
     outputs:
       Exp Bottle:
         material: EXP_BOTTLE

--- a/config.yml
+++ b/config.yml
@@ -4160,8 +4160,9 @@ production_recipes:
         material: LONG_GRASS
         amount: 32
         durability: 1
-      Cooked Fish:
-        material: COOKED_FISH
+      Ink:
+        material: 'INK_SACK'
+        durability: 0
         amount: 16
     outputs:
       Exp Bottle:


### PR DESCRIPTION
As discussed in https://github.com/Civcraft/FactoryMod/issues/34 , instead of 16 cooked fish we use 16 ink sacks for the mob drop item in recipe 3. This makes ocean biomes more useful and makes recipe 3 a lot harder to bot, in line with the other recipes. Let me know what if this is a bad idea. 