### PR TITLE
Bastion Recipe Nerf

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7425,7 +7425,7 @@ production_recipes:
     outputs:
       Bastion:
         material: SPONGE
-        amount: 32
+        amount: 16
         display_name: Bastion
   Sequencing_Sunflower:
     name: Sequencing Sunflower


### PR DESCRIPTION
Cuts the amount of bastions produced per recipe in half (16 bastions down from 32). This doubles the cost of bastions