### PR TITLE
CLAY_BALL to CLAY change

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4579,8 +4579,8 @@ production_recipes:
     production_time: 32
     inputs:
       Clay:
-        material: CLAY_BALL
-        amount: 512
+        material: CLAY
+        amount: 128
     outputs:
       Bricks:
         material: CLAY_BRICK
@@ -4590,8 +4590,8 @@ production_recipes:
     production_time: 5
     inputs:
       Clay:
-        material: CLAY_BALL
-        amount: 64
+        material: CLAY
+        amount: 16
     outputs:
       Flower Pots:
         material: FLOWER_POT_ITEM


### PR DESCRIPTION
Changed CLAY_BALL recipe to CLAY recipes so people don't waste time breaking laying down clay blocks into clay balls just to run it through the factory. Divided clay_ball values by 4 since it takes 4 balls to make one block.