### PR TITLE
PrintingPress actual status message while factory is running

### DIFF
--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -48,7 +48,7 @@ public class FactoryModPlugin extends JavaPlugin
 	public NetherFactoryProperties netherFactoryProperties;
 	public RepairFactoryProperties repairFactoryProperties;
 	
-	public static final String VERSION = "v1.3.4"; //Current version of plugin
+	public static final String VERSION = "v1.3.5"; //Current version of plugin
 	public static final String PLUGIN_NAME = "FactoryMod"; //Name of plugin
 	public static final String PLUGIN_PREFIX = PLUGIN_NAME + " " + VERSION + ": ";
 	public static final String PRODUCTION_SAVES_FILE = "productionSaves"; // The production saves file name

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -48,7 +48,7 @@ public class FactoryModPlugin extends JavaPlugin
 	public NetherFactoryProperties netherFactoryProperties;
 	public RepairFactoryProperties repairFactoryProperties;
 	
-	public static final String VERSION = "v1.0"; //Current version of plugin
+	public static final String VERSION = "v1.3.4"; //Current version of plugin
 	public static final String PLUGIN_NAME = "FactoryMod"; //Name of plugin
 	public static final String PLUGIN_PREFIX = PLUGIN_NAME + " " + VERSION + ": ";
 	public static final String PRODUCTION_SAVES_FILE = "productionSaves"; // The production saves file name

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -513,13 +513,21 @@ public class PrintingPress extends BaseFactory {
 			if (mode == OperationMode.PRINT_BOOKS ||
 				 mode == OperationMode.PRINT_PAMPHLETS ||
 				 mode == OperationMode.PRINT_SECURITY) {
-				queueContents.append("Queue Contents: ");
+				queueContents.append("Queue Contents: [");
 				for (int i = 0; i < processQueue.length; i++) {
 					readyCopies += processQueue[i];
-					queueContents.append("[");
+					if (i > 0) {
+						queueContents.append(",");
+					}
+					if (i == processQueueOffset) {
+						queueContents.append("{");
+					}
 					queueContents.append(processQueue[i]);
-					queueContents.append("]");
+					if (i == processQueueOffset) {
+						queueContents.append("}");
+					}
 				}
+				queueContents.append("]");
 			}
 			switch(mode) {
 			case PRINT_BOOKS:

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -507,11 +507,12 @@ public class PrintingPress extends BaseFactory {
 
 
 		//[% done if plates; queue status else]
-		if (active && mode != REPAIR) {
+		if (active && mode != OperationMode.REPAIR) {
 			int readyCopies = 0;
-			StringBuffer queueContents;
-			if (mode == PRINT_BOOKS || mode == PRINT_PAMPHLETS || mode == PRINT_SECURITY) {
-				queueContents = new StringBuffer();
+			StringBuffer queueContents = new StringBuffer();
+			if (mode == OperationMode.PRINT_BOOKS ||
+				 mode == OperationMode.PRINT_PAMPHLETS ||
+				 mode == OperationMode.PRINT_SECURITY) {
 				queueContents.append("Queue Contents: ");
 				for (int i = 0; i < processQueue.length; i++) {
 					readyCopies += processQueue[i];
@@ -543,8 +544,9 @@ public class PrintingPress extends BaseFactory {
 						String.valueOf(percentComplete) + "% complete"));
 				break;
 			default:
-				log.debug("getChestResponse(): Active set, but unknown mode: critical error.");
+				log.severe("getChestResponse(): Active set, but unknown mode: critical error.");
 				break;
+			}
 		}
 
 		return responses;
@@ -567,7 +569,7 @@ public class PrintingPress extends BaseFactory {
 	 * progress in a recipe, for instance.
 	 */
 	private int getBookInventoryPages() {
-		if (ItemStack stack : getInventory().getContents() {
+		for (ItemStack stack : getInventory().getContents()) {
 			if (stack == null) {
 				continue;
 			}


### PR DESCRIPTION
Pet peave of mine, factories had no status messages whatsoever when running. This adds status to all the PP recipes. 

For Plates, gives percentage completion. 

For Books, Pamphlets, and Security Notes, gives current # of items in the queue ("being printed"), and the current progress within the queue.

Tested against 1.7.10; this code doesn't care about the 1.8 changes, so shouldn't be a problem, but don't merge until I've gotten my 1.8 env up and tested.