### PR TITLE
Adding recipts for prismarine blocks and sea lanterns

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7607,7 +7607,7 @@ production_recipes:
         material: PRISMARINE_SHARD
         amount: 128
     outputs:
-      Prismarine
+      Prismarine:
         material: PRISMARINE
         amount: 64
         durability: 0
@@ -7619,7 +7619,7 @@ production_recipes:
         material: PRISMARINE_SHARD
         amount: 288
     outputs:
-      Prismarine
+      Prismarine:
         material: PRISMARINE
         amount: 64
         durability: 1
@@ -7635,7 +7635,7 @@ production_recipes:
         amount: 32
         durability: 0
     outputs:
-      Prismarine
+      Prismarine:
         material: PRISMARINE
         amount: 64
         durability: 2
@@ -7650,6 +7650,6 @@ production_recipes:
         material: PRISMARINE_CRYSTALS
         amount: 64
     outputs:
-      Prismarine
+      Sea Lantern:
         material: SEA_LANTERN
         amount: 16

--- a/config.yml
+++ b/config.yml
@@ -7653,3 +7653,4 @@ production_recipes:
       Prismarine
         material: SEA_LANTERN
         amount: 16
+		

--- a/config.yml
+++ b/config.yml
@@ -1895,7 +1895,11 @@ production_factories:
         amount: 256
         durability: 4
     recipes:
+      - Smelt Prismarine
+      - Smelt Prismarine Bricks
+      - Smelt Dark Prismarine
       - Smelt_Cracked_Stone_Brick
+      - Craft Sea Lanterns
       - Smelt_Mossy_Stone_Brick
       - Smelt_Chiseled_Stone_Brick
       - Bastion_Flooring
@@ -7595,3 +7599,57 @@ production_recipes:
        Eye of Ender:
          material: EYE_OF_ENDER
          amount: 256
+  Smelt Prismarine:
+    name: Smelt Prismarine
+    production_time: 16
+    inputs:
+      Prismarine Shard:
+        material: PRISMARINE_SHARD
+        amount: 128
+    outputs:
+      Prismarine
+        material: PRISMARINE
+        amount: 64
+        durability: 0
+  Smelt Prismarine Bricks:
+    name: Smelt Prismarine Bricks
+    production_time: 16
+    inputs:
+      Prismarine Shard:
+        material: PRISMARINE_SHARD
+        amount: 288
+    outputs:
+      Prismarine
+        material: PRISMARINE
+        amount: 64
+        durability: 1
+  Smelt Dark Prismarine:
+    name: Smelt Dark Prismarine
+    production_time: 16
+    inputs:
+      Prismarine Shard:
+        material: PRISMARINE_SHARD
+        amount: 256
+      Ink Sack:
+        material: INK_SACK
+        amount: 32
+        durability: 0
+    outputs:
+      Prismarine
+        material: PRISMARINE
+        amount: 64
+        durability: 2
+  Craft Sea Lanterns:
+    name: Craft Sea Lanterns
+    production_time: 8
+    inputs:
+      Prismarine Shard:
+        material: PRISMARINE_SHARD
+        amount: 32
+      Prismarine Crystals:
+        material: PRISMARINE_CRYSTALS
+        amount: 64
+    outputs:
+      Prismarine
+        material: SEA_LANTERN
+        amount: 16

--- a/config.yml
+++ b/config.yml
@@ -7653,4 +7653,3 @@ production_recipes:
       Prismarine
         material: SEA_LANTERN
         amount: 16
-		


### PR DESCRIPTION
This would add recipts for all 3 variants of prismarine and sea lanterns to the fancy stonebrick smelter. The balancing is in line with other decorational blocks and basically doubles, what you would get from crafting. Sea lanterns still require 4 crystals per sea lantern, because otherwise it would be possible to get an infinite amount of crystals by destroying lanterns with Fortune 3. Fancy stonebrick smelter seemed like the right factory for it, because aside from the bastion recipt, it's already used only for decorational blocks.