### PR TITLE
Flooring clay balls to blocks. Added brick_block to kiln.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -850,6 +850,7 @@ production_factories:
       - Bake_clay_blocks
       - Bake_bricks
       - Bake_pots
+      - Bake_brick_blocks
     repair_multiple: 26
     repair_inputs:
       Clay:
@@ -4556,7 +4557,7 @@ production_recipes:
         material: HARD_CLAY
         amount: 1024
   Bake_bricks:
-    name: Bake Bricks
+    name: Bake Individual Bricks
     production_time: 32
     inputs:
       Clay:
@@ -4577,6 +4578,17 @@ production_recipes:
       Flower Pots:
         material: FLOWER_POT_ITEM
         amount: 64
+  Bake_brick_blocks:
+    name: Bake Brick Blocks
+    production_time: 32
+    inputs:
+      Clay:
+        material: CLAY
+        amount: 128
+    outputs:
+      Brick blocks:
+        material: BRICK_BLOCK
+        amount: 256
   Smelt_Sandstone:
     name: Smelt Sandstone
     production_time: 32
@@ -7364,8 +7376,8 @@ production_recipes:
     name: Flooring
     inputs:
       Clay Ball:
-        material: CLAY_BALL
-        amount: 32
+        material: CLAY
+        amount: 8
       Nether Brick:
         material: NETHER_BRICK
         amount: 64


### PR DESCRIPTION
Flooring change is just another extension of this pull: https://github.com/Civcraft/FactoryMod/pull/71

Kiln only currently makes individual bricks, which has no other use than making flower pots. Left that individual brick recipe in because I'm not sure if it serves any other purpose. 

However, I added brick_block recipe, which is what most people want when smelting clay for brick.