### PR TITLE
Clean compile, break-fix v1

### DIFF
--- a/src/com/github/igotyou/FactoryMod/persistence/NetherCsvReader.java
+++ b/src/com/github/igotyou/FactoryMod/persistence/NetherCsvReader.java
@@ -12,6 +12,7 @@ import org.bukkit.World;
 import com.github.igotyou.FactoryMod.FactoryModPlugin;
 import com.github.igotyou.FactoryMod.Factorys.NetherFactory;
 import com.github.igotyou.FactoryMod.Factorys.NetherFactory.NetherOperationMode;
+import com.github.igotyou.FactoryMod.managers.NetherFactoryManager;
 import com.google.common.collect.Lists;
 
 public class NetherCsvReader implements IFactoryReader<NetherFactory> {
@@ -102,9 +103,8 @@ public class NetherCsvReader implements IFactoryReader<NetherFactory> {
 		long timeDisrepair  = input.readLong();
 		
 		return new NetherFactory(centerLocation, inventoryLocation, powerLocation, netherTeleportPlatformLocation, overworldTeleportPlatformLocation,
-				active, currentRepair, timeDisrepair,
-				mode,
-				mPlugin.getNetherFactoryProperties(), this);
+				active, currentRepair, timeDisrepair, mode, mPlugin.getNetherFactoryProperties(),
+				(NetherFactoryManager) mPlugin.manager.getManager(NetherFactoryManager.class));
 	}
 
 }


### PR DESCRIPTION
@WildWeazel  NetherFactory needs to recompute scaling factor during repair, so NetherFactoryManager is a hard dependency. Simply fixed compilation error by pulling the manager from the plugin. Not tested locally, that's up next, but IRL first. I'd be much appreciative if you could pull and test locally.