### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6685,7 +6685,7 @@ production_recipes:
     inputs:
       Iron Ingot:
         material: IRON_INGOT
-        amount: 54
+        amount: 18
     outputs:
       Iron Door:
         material: IRON_DOOR


### PR DESCRIPTION
Update the iron door recipe. Since 1.8 It is cheaper to make iron doors using a crafting table(6 iron for 3 doors). I think 1 iron per door in the factory is reasonable.