### PR TITLE
Fix redstone listener for new factories

### DIFF
--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -195,7 +195,7 @@ public class FactoryModPlugin extends JavaPlugin
 		try
 		{
 			getServer().getPluginManager().registerEvents(new FactoryModListener(manager), this);
-			getServer().getPluginManager().registerEvents(new RedstoneListener(manager, (ProductionFactoryManager) manager.getManager(ProductionFactory.class)), this);
+			getServer().getPluginManager().registerEvents(new RedstoneListener(manager), this);
 			getServer().getPluginManager().registerEvents(new NoteStackListener(this), this);
 		}
 		catch(Exception e)

--- a/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
@@ -14,23 +14,21 @@ import vg.civcraft.mc.citadel.ReinforcementManager;
 import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
 
 import com.github.igotyou.FactoryMod.FactoryModPlugin;
+import com.github.igotyou.FactoryMod.Factorys.ABaseFactory;
 import com.github.igotyou.FactoryMod.Factorys.ProductionFactory;
 import com.github.igotyou.FactoryMod.managers.FactoryManagerService;
-import com.github.igotyou.FactoryMod.managers.ProductionFactoryManager;
 
 public class RedstoneListener implements Listener {
 	private FactoryManagerService factoryMan;
 	private ReinforcementManager rm = Citadel.getReinforcementManager();
 	//this is a lazy fix...
-	private ProductionFactoryManager productionMan;
 	
 	/**
 	 * Constructor
 	 */
-	public RedstoneListener(FactoryManagerService factoryManager, ProductionFactoryManager productionManager)
+	public RedstoneListener(FactoryManagerService manager)
 	{
-		this.factoryMan = factoryManager;
-		this.productionMan = productionManager;
+		this.factoryMan = manager;
 	}
 	
 	@EventHandler(ignoreCancelled = true)
@@ -98,22 +96,18 @@ public class RedstoneListener implements Listener {
 			if(block.getType() == Material.FURNACE || block.getType() == Material.BURNING_FURNACE)
 			{
 				if (factoryMan.factoryExistsAt(block.getLocation()))
-				{					
-					//Is the factory a production factory?
-					if (productionMan.factoryExistsAt(block.getLocation()))
-					{
-						ProductionFactory factory = (ProductionFactory) productionMan.getFactory(block.getLocation());
+				{
+					ABaseFactory factory = (ABaseFactory) factoryMan.getFactory(block.getLocation());
 						
-						Block lever = factory.findActivationLever();
-						if (lever == null) {
-							// No lever - don't respond to redstone
-							return;
-						}
+					Block lever = factory.findActivationLever();
+					if (lever == null) {
+						// No lever - don't respond to redstone
+						return;
+					}
 						
-						if (!factory.getActive()) {
-							// Try to start the factory
-							factory.togglePower();
-						}
+					if (!factory.getActive()) {
+						// Try to start the factory
+						factory.togglePower();
 					}
 				}
 			}


### PR DESCRIPTION
Adressing https://github.com/Civcraft/FactoryMod/issues/120

So, whenever a redstone signal was applied to a factory previously, it would only do something if it was a production factory, this was apparently intended at the time it was coded. We want to turn on any type of factories so I removed that check and let it use ABaseFactory, from which all the factories extend, that should allow all factories to be started by redstone.