### PR TITLE
Prevent placement of and crafting with compacted items

### DIFF
--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -23,6 +23,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import com.github.igotyou.FactoryMod.FactoryObject.FactoryType;
 import com.github.igotyou.FactoryMod.Factorys.ProductionFactory;
+import com.github.igotyou.FactoryMod.listeners.CompactItemListener;
 import com.github.igotyou.FactoryMod.listeners.FactoryModListener;
 import com.github.igotyou.FactoryMod.listeners.NoteStackListener;
 import com.github.igotyou.FactoryMod.listeners.RedstoneListener;
@@ -197,6 +198,7 @@ public class FactoryModPlugin extends JavaPlugin
 			getServer().getPluginManager().registerEvents(new FactoryModListener(manager), this);
 			getServer().getPluginManager().registerEvents(new RedstoneListener(manager), this);
 			getServer().getPluginManager().registerEvents(new NoteStackListener(this), this);
+			getServer().getPluginManager().registerEvents(new CompactItemListener(compactorProperties.getCompactLore()),this);
 		}
 		catch(Exception e)
 		{

--- a/src/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
@@ -1,0 +1,61 @@
+package com.github.igotyou.FactoryMod.listeners;
+
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.ItemStack;
+
+public class CompactItemListener implements Listener{
+	private String compactLore;	
+	
+	public CompactItemListener(String compactLore) {
+		this.compactLore = compactLore;
+	}
+	
+	@EventHandler
+	public void blockPlaceEvent(BlockPlaceEvent e) {
+		if (!e.getItemInHand().hasItemMeta()) {
+			return;
+		}
+		if (!e.getItemInHand().getItemMeta().hasLore()) {
+			return;
+		}
+		if (e.getItemInHand().getItemMeta().getLore().get(0).equals(compactLore)) {
+			e.setCancelled(true);
+			Player p = e.getPlayer();
+			if (p != null) {
+			p.sendMessage("You can not place compacted blocks");
+			}
+		}
+		
+	}
+	
+	@EventHandler
+	public void craftingEvent(CraftItemEvent e) {
+		CraftingInventory ci = e.getInventory();
+		for(ItemStack is:ci.getMatrix()) {
+			if (is == null) {
+				continue;
+			}
+			if (!is.hasItemMeta()) {
+				continue;
+			}
+			if (!is.getItemMeta().hasLore()) {
+				continue;
+			}
+			if (is.getItemMeta().getLore().get(0).equals(compactLore)) {
+				e.setCancelled(true);
+				HumanEntity h = e.getWhoClicked();
+				if (h instanceof Player && h != null) {
+				((Player)h).sendMessage("You can not craft with compacted items");
+				}
+				break;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Just an utility to protect players from themselves, because currently placing a compacted block or crafting something with compacted items just treats them as normal items, effectively deleting many items. This is already as a warning in the documentation for compactors, but not too many people read that, so I think having this as an additional safety net would be a good idea. There are still a few ways to get rid of compacted items, but this should cover the most common "miss click" or "no one told me" actions. Could also be code recycled for contraptions easily.

@ProgrammerDan Your opinion on this as the guy who coded compactors?