### PR TITLE
Fix for smooth double slabs and adding 6sided logs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -421,30 +421,94 @@ crafting:
           amount: 9
     Stone Slab to Double Slab:
       inputs:
-        s:
-         Stone Slab:
-           material: STONE_SLAB2
-      shape:
-        - s
-        - s
+        Stone Slab:
+          material: STEP
+          amount: 9
       output:
         Double Stone Slab:
-          material: STONE_SLAB2
+          material: STEP
+          amount: 4
           lore: Smooth double slab
     Sandstone Slab to Double Slab:
       inputs:
-        s:
-         Sandstone Slab:
-           material: STONE_SLAB2
-           durability: 1
-      shape:
-        - s
-        - s
+        Sandstone Slab:
+          material: STEP
+          durability: 1
+          amount: 9
       output:
         Double Sandstone Slab:
-          material: STONE_SLAB2
+          material: STEP
           durability: 1
           lore: Smooth double slab 
+          amount: 4
+    Sixsided oaklog:
+      inputs:
+        Oak log:
+          material: log
+          amount: 9
+      output:
+        6sided log:
+          material: log
+          amount: 6
+          lore: Sixsided log
+    Sixsided sprucelog:
+      inputs:
+        Spruce log:
+          material: log
+          amount: 9
+          durability: 1
+      output:
+        6sided log:
+          material: log
+          amount: 6
+          lore: Sixsided log
+          durability: 1
+    Sixsided birchlog:
+      inputs:
+        Birch log:
+          material: log
+          amount: 9
+          durability: 2
+      output:
+        6sided log:
+          material: log
+          amount: 6
+          lore: Sixsided log
+          durability: 2
+    Sixsided junglelog:
+      inputs:
+        jungle log:
+          material: log
+          amount: 9
+          durability: 3
+      output:
+        6sided log:
+          material: log
+          amount: 6
+          lore: Sixsided log
+          durability: 3
+    Sixsided acacialog:
+      inputs:
+        acacia log:
+          material: log_2
+          amount: 9
+      output:
+        6sided log:
+          material: log_2
+          amount: 6
+          lore: Sixsided log 
+    Sixsided dark oaklog:
+      inputs:
+        dark oak log:
+          material: log_2
+          amount: 9
+          durability: 1
+      output:
+        6sided log:
+          material: log_2
+          amount: 6
+          lore: Sixsided log   
+          durability: 1          
 production_factories:
   Bakery:
     name: Bakery

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -314,8 +314,8 @@ public class FactoryModPlugin extends JavaPlugin
 				
 				for (ItemStack input:getItems(configSection.getConfigurationSection("inputs")))
 				{
-					shapelessRecipe.addIngredient(input.getAmount(), input.getType());
-					//shapelessRecipe.addIngredient(input.getAmount(), input.getType(), input.getDurability());
+					//shapelessRecipe.addIngredient(input.getAmount(), input.getType());
+					shapelessRecipe.addIngredient(input.getAmount(), input.getType(), input.getDurability());
 				}
 				
 				recipe = shapelessRecipe;

--- a/src/com/github/igotyou/FactoryMod/listeners/FactoryModListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/FactoryModListener.java
@@ -501,25 +501,36 @@ public class FactoryModListener implements Listener
 	}
 
 	/**
-	 * Turns slabs with the lore "Smooth double slab" into smooth double slab blocks
+	 * Turns slabs with the lore "Smooth double slab" into smooth double slab blocks and logs
+	 * with the lore "6-sided log" into logs with the log texture on all 6 sides
 	 * @param e
 	 */
 	@EventHandler
-	public void onDoubleSlabUse(BlockPlaceEvent e) {
-	    Material material = e.getBlock().getType();
-	    if (material != Material.STONE_SLAB2) {
-	    	return;
-	    }
-	    org.bukkit.inventory.ItemStack is = e.getItemInHand();
+	public void onSpecialBlockUse(BlockPlaceEvent e) {
+		org.bukkit.inventory.ItemStack is = e.getItemInHand();
 	    if (!is.hasItemMeta() || !is.getItemMeta().hasLore()) {
 	    	return;
 	    }
+	    Material material = e.getBlock().getType();
 	    ItemMeta blockMeta = is.getItemMeta();
-	    if (blockMeta.getLore().get(0).equals("Smooth double slab")) {
-	    	Block block = e.getBlock();
-	    	byte type = (byte)(is.getDurability() + 8);
-	    	block.setTypeIdAndData(Material.DOUBLE_STONE_SLAB2.getId(),type,true);
-	    	}
-	  }
-	  
+	    switch (material) {
+	    case STEP:
+		    if (blockMeta.getLore().get(0).equals("Smooth double slab")) {
+		    	byte type = (byte)(is.getDurability() + 8);
+		    	e.getBlock().setTypeIdAndData(Material.DOUBLE_STEP.getId(),type,true);
+		    	}
+	    	break;
+	    case LOG:
+	    case LOG_2:
+		    if (blockMeta.getLore().get(0).equals("Sixsided log")) {
+		    	byte type = (byte)((is.getDurability()%4)+12);
+		    	e.getBlock().setTypeIdAndData(material.getId(),type,true);
+		    	}
+	    	
+	    	break;
+	    	default:
+	    		return;
+	    }
+	    
+}
 }


### PR DESCRIPTION
The listener for the double slabs worked, but the crafting recipes didn't, because the code for that didnt support different durabilities. I would guess that the line to support that was commented out because it's deprecated, but there is no replacement for it and there are no downsides when using it.

Also added logs, which have the log texture on all 6 sides.