### PR TITLE
Crate Refund. 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -277,6 +277,7 @@ compactor:
         display_name: Crate
         lore: A crate for compacting items
   compact_lore: Compacted Item
+  refund_chance: 1.0
   continuous: true
   specific_exclusions:
   excluded_types:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.github.igotyou</groupId>
 	<artifactId>FactoryMod</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.2</version>
+	<version>1.4.3</version>
 	<name>FactoryMod</name>
 	<url>https://github.com/Civcraft/FactoryMod</url>
 

--- a/src/com/github/igotyou/FactoryMod/Factorys/Compactor.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/Compactor.java
@@ -149,7 +149,12 @@ public class Compactor extends ABaseFactory {
                     cloneMeta.setLore(null);
                     clone.setItemMeta(cloneMeta);
                     outputs.add(clone); 
-                	
+
+                    // Refund crates based on a percentage. 1.0 = 100%, 0.0 == 0% based on random()'s [0,1) distribution.
+                    if (Math.random() < cp.getRefundChance()) {
+                        outputs.addAll(cp.getRecipeMaterials());
+                    }
+
                     return outputs;
                 }
             }

--- a/src/com/github/igotyou/FactoryMod/properties/CompactorProperties.java
+++ b/src/com/github/igotyou/FactoryMod/properties/CompactorProperties.java
@@ -23,6 +23,7 @@ public class CompactorProperties extends AFactoryProperties{
     private int repair;
     private double repairTime;
     private double productionTime;
+    private double refundChance;
     private String compactLore;
     private boolean continuous;
     
@@ -30,7 +31,7 @@ public class CompactorProperties extends AFactoryProperties{
     public CompactorProperties(ItemList<NamedItemStack> constructionMaterials,
             ItemList<NamedItemStack> fuel, ItemList<NamedItemStack> repairMaterials,
             ItemList<NamedItemStack> recipeMaterials, int energyTime, int repair, 
-            String name, double repairTime, double productionTime, String compactLore,
+            String name, double repairTime, double productionTime, double refundChance, String compactLore,
             boolean continuous, ItemList<NamedItemStack> specificExclusion, List<Material> generalExclusion) {
         this.constructionMaterials = constructionMaterials;
         this.fuel = fuel;
@@ -41,6 +42,7 @@ public class CompactorProperties extends AFactoryProperties{
         this.name = name;
         this.repairTime = repairTime;
         this.productionTime = productionTime;
+        this.refundChance = refundChance;
         this.compactLore = compactLore;
         this.continuous = continuous;
         this.specificExclusions = specificExclusion;
@@ -87,6 +89,10 @@ public class CompactorProperties extends AFactoryProperties{
         return productionTime;
     }
 
+    public double getRefundChance() {
+        return refundChance;
+    }
+
     public String getCompactLore() {
         return compactLore;
     }
@@ -112,6 +118,7 @@ public class CompactorProperties extends AFactoryProperties{
         String name = config.getString("name", "Compactor");
         int repairTime = config.getInt("repair_time", 12);
         int productionTime = config.getInt("production_time");
+        double refundChance = config.getDouble("refund_chance", 1.0);
         String compactLore = config.getString("compact_lore", "Compacted Item");
         boolean continuous = config.getBoolean("continuous", false);
 		Iterator<NamedItemStack> genExcludeIter = generalExclusion.iterator();
@@ -123,7 +130,7 @@ public class CompactorProperties extends AFactoryProperties{
 			generalExclude.add(exclude.getType());
 		}
 
-        return new CompactorProperties(constructionCost, cFuel, repairCost, recipeUse, energyTime, repair, name, repairTime, productionTime, compactLore, continuous, specificExclusion, generalExclude);
+        return new CompactorProperties(constructionCost, cFuel, repairCost, recipeUse, energyTime, repair, name, repairTime, productionTime, refundChance, compactLore, continuous, specificExclusion, generalExclude);
     }
 
 }


### PR DESCRIPTION
Adding chance based crate refund, defaulting to full refund on decompaction.

Technically it's just a recipe cost refund, so if crates are ever altered this will continue to work. 

Also the checkIfFull test will have unreliable outcomes for values other then 0.0 and 1.0 on refund_chance, as I'm not locking the random generator... we can deal with that later if for some reason we consider values other then 100% (1.0)