### PR TITLE
Fm2 redstone

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,8 @@ citadel_enabled: true
 factory_interaction_material: STICK
 disable_nether: true
 default_update_time: 4
+redstone_power_on: 7
+redstone_recipe_change: 2
 
 crafting:
     disabled:

--- a/src/com/github/igotyou/FactoryMod/ConfigParser.java
+++ b/src/com/github/igotyou/FactoryMod/ConfigParser.java
@@ -58,8 +58,10 @@ public class ConfigParser {
 					.registerEvents(new NetherPortalListener(), plugin);
 		}
 		int defaultUpdateTime = config.getInt("default_update_time", 4);
+		int redstonePowerOn = config.getInt("redstone_power_on", 7);
+		int redstoneRecipeChange = config.getInt("redstone_recipe_change", 2);
 		manager = new FactoryModManager(plugin, factoryInteractionMaterial,
-				citadelEnabled);
+				citadelEnabled, redstonePowerOn, redstoneRecipeChange);
 		handleEnabledAndDisabledRecipes(config
 				.getConfigurationSection("crafting"));
 		parseRecipes(config.getConfigurationSection("recipes"));

--- a/src/com/github/igotyou/FactoryMod/FactoryModManager.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModManager.java
@@ -29,13 +29,17 @@ public class FactoryModManager {
 	private HashSet<Material> possibleInteractionBlock;
 	private Material factoryInteractionMaterial;
 	private boolean citadelEnabled;
+	private int redstonePowerOn;
+	private int redstoneRecipeChange;
 	private String compactLore;
 
 	public FactoryModManager(FactoryModPlugin plugin,
-			Material factoryInteractionMaterial, boolean citadelEnabled) {
+			Material factoryInteractionMaterial, boolean citadelEnabled, int redstonePowerOn, int redstoneRecipeChange) {
 		this.plugin = plugin;
 		this.factoryInteractionMaterial = factoryInteractionMaterial;
 		this.citadelEnabled = citadelEnabled;
+		this.redstonePowerOn = redstonePowerOn;
+		this.redstoneRecipeChange = redstoneRecipeChange;
 
 		factoryCreationRecipes = new HashMap<Class<MultiBlockStructure>, HashMap<ItemMap, IFactoryEgg>>();
 		locations = new HashMap<Location, Factory>();
@@ -251,5 +255,26 @@ public class FactoryModManager {
 	 */
 	public IFactoryEgg getEgg(String name) {
 		return eggs.get(name);
+	}
+	
+	/**
+	 * Gets the Redstone power level necessary to active a factory.
+	 * Fall below this level and the factory will deactivate.
+	 *  
+	 * @return The power level on which factory activation or de-activation hinges
+	 */
+	public int getRedstonePowerOn() {
+		return this.redstonePowerOn;
+	}
+	
+	/**
+	 * Gets the Redstone power change necessary to alter the recipe setting of a factory.
+	 * Any change >= this level, either positive or negative, will attempt to alter the recipe 
+	 *   (implementation depending).
+	 *   
+	 * @return The amount of Redstone power change necessary to alter recipe setting of a factory.
+	 */
+	public int getRedstoneRecipeChange() {
+		return this.redstoneRecipeChange;
 	}
 }

--- a/src/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
+++ b/src/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
@@ -69,8 +69,7 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
 		if (e.getNewCurrent() == e.getOldCurrent()) {
 			return;
 		}
-		int threshold = 1;
-		int rThreshold = 1;
+		int threshold = FactoryModPlugin.getManager().getRedstonePowerOn();
 		boolean newState = false;
 		if (e.getBlock().getLocation().equals(fccf.getFurnace().getLocation())) {
 			if (e.getOldCurrent() >= threshold && e.getNewCurrent() < threshold && fccf.isActive()) {
@@ -92,7 +91,7 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
 				((FurnCraftChestStructure) fccf.getMultiBlockStructure()).getCraftingTable())) {
 			// Can't change recipe while active.
 			int change = e.getOldCurrent() - e.getNewCurrent();
-			if (Math.abs(change) >= rThreshold) {
+			if (Math.abs(change) >= FactoryModPlugin.getManager().getRedstoneRecipeChange()) {
 				List<IRecipe> currentRecipes = fccf.getRecipes();
 				if (currentRecipes.size() == 0) {
 					return;

--- a/src/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
+++ b/src/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
@@ -83,7 +83,7 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
 			}
 			
 			if (newState) {
-				fccf.activate();
+				fccf.attemptToActivate(null);
 			} else {
 				fccf.deactivate();
 			}
@@ -280,7 +280,7 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
 			ci.showInventory(p);
 			return;
 		}
-		if (b.equals(fccf.getFurnace()) { // furnace interaction
+		if (b.equals(fccf.getFurnace())) { // furnace interaction
 			if (fccf.isActive()) {
 				fccf.deactivate();
 			} else {


### PR DESCRIPTION
Adds advanced redstone controls to FactoryMod 2.0 Refactory.

Two principle control modes:

* Furnace control. If "rising edge" of redstone power exceeds a threshold, attempt to turn the factory on. If "falling edge" of redstone power falls below the threshold, attempt to turn the factory off. Recommended value: power 7.

* Recipe control. If redstone power increases past some "difference" threshold, cycle "up" the recipe list. If redstone power decreases past some "difference" threshold, cycle "down" the recipe list. Recommended value: power 2. That way, clever designers can alter recipes consistently (by creating a circuit that creates a power difference greater then 2, and subsequently returns to "stable" in intervals of power difference 1). A difference of 1 is not recommended.

Both control modes respect Citadel, if enabled. Only Directly powered Redstone signals are considered, and redstone signals reinforced to a different group from the factory are ignored, unless the factory is on a "public" group, in which case all signals are considered.

Other factory control aspects are respected, such as ability to be activated (sufficient fuel, input, etc.) as well as recipes cannot be changed while factory is active. 

This needs testing within the overall refactor effort.