### PR TITLE
Addressing local build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>Spigot1.8.7</artifactId>
-			<version>1.8.7</version>
+			<artifactId>spigot-api</artifactId>
+			<version>1.8.7-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>vg.civcraft.mc.civmodcore</groupId>
 			<artifactId>CivModCore</artifactId>
-			<version>[1.0.8]</version>
+			<version>1.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
I don't think we're using any custom API calls we've baked into our own build of Spigot, so altered to point to public release.

Additionally, the interaction manager uses the new Clickable construction that was added in CivModCore 1.1.0, so addressing that.