### PR TITLE
Add recipe for smelting acacia and dark oak logs

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -231,6 +231,7 @@ factories:
     name: Coal Burner
     recipes:
     - Burn_Charcoal_from_Logs_Expert
+    - Burn_Charcoal_from_Logs2_Expert
     - Burn_Charcoal_from_Coal
     - Repair_Small_Factory
   farmsteadfactory:
@@ -779,6 +780,20 @@ recipes:
     input:
       log:
         material: LOG
+        durability: -1
+        amount: 512
+    output:
+      charcoal:
+        material: COAL
+        amount: 1024
+        durability: 1
+  Burn_Charcoal_from_Logs2_Expert:
+    type: PRODUCTION
+    name: Burn Charcoal from Logs2
+    production_time: 45s
+    input:
+      log:
+        material: LOG_2
         durability: -1
         amount: 512
     output:


### PR DESCRIPTION
Acacia and Dark Oak logs are a completely different material (LOG_2), than the other wood so it can't currently be used in the Coal Burner factory.

Ideally, the code would support substitute materials, that's what I did for my own implementation, but this is at least a temporary fix.