### PR TITLE
Fix issue with getting the inventory of double chests that are placed…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.github.igotyou</groupId>
 	<artifactId>FactoryMod</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.9</version>
+	<version>2.0.10</version>
 	<name>FactoryMod</name>
 	<url>https://github.com/Civcraft/FactoryMod</url>
 


### PR DESCRIPTION
… on the border between two chunks

@Maxopoly I confirmed this was the issue with factories upgrading suddenly stopping due to running out of materials.