### PR TITLE
fix fancy stone ratios

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -1520,7 +1520,7 @@ recipes:
   Craft_Polished_Andesite:
     type: PRODUCTION
     name: Craft Polished Andesite
-    production_time: 10s
+    production_time: 8s
     input:
       andesite:
         material: STONE
@@ -1530,11 +1530,11 @@ recipes:
       polished andesite:
         material: STONE
         durability: 6
-        amount: 32
+        amount: 88
   Craft_Polished_Diorite:
     type: PRODUCTION
     name: Craft Polished Diorite
-    production_time: 10s
+    production_time: 8s
     input:
       andesite:
         material: STONE
@@ -1544,11 +1544,11 @@ recipes:
       polished andesite:
         material: STONE
         durability: 4
-        amount: 32
+        amount: 88
   Craft_Polished_Granite:
     type: PRODUCTION
     name: Craft Polished Granite
-    production_time: 10s
+    production_time: 8s
     input:
       andesite:
         material: STONE
@@ -1558,7 +1558,7 @@ recipes:
       polished andesite:
         material: STONE
         durability: 2
-        amount: 32
+        amount: 88
   Craft_Prismarine_Basic:
     type: PRODUCTION
     name: Craft Prismarine


### PR DESCRIPTION
currently the recipes for andesite/diorite/granite cost you 5 charcoal to get you half the output you'd get from crafting a stack manually
this buffs the recipes from 50% to 140% output and reduces the coal cost by 1 (1 coal to 24 output) to bring them in-line with the factory's cobble->stone recipe, which seems fair as they're only decorative blocks in the first place.