### PR TITLE
Reduced meat cost

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -4454,10 +4454,10 @@ recipes:
         amount: 256
       chicken:
         material: COOKED_CHICKEN
-        amount: 96
+        amount: 32
       beef:
         material: GRILLED_PORK
-        amount: 96
+        amount: 32
     factory: Farmstead Factory
   Upgrade_to_Fine_Woodworking:
     production_time: 900s
@@ -6337,7 +6337,7 @@ recipes:
         amount: 128
       chicken:
         material: RAW_CHICKEN
-        amount: 32
+        amount: 10
       aether:
         material: GOLD_NUGGET
         amount: 168
@@ -6372,7 +6372,7 @@ recipes:
         durability: 3
       beef:
         material: RAW_BEEF
-        amount: 32
+        amount: 16
       aether:
         material: GOLD_NUGGET
         amount: 168
@@ -6406,7 +6406,7 @@ recipes:
         amount: 128
       pork:
         material: PORK
-        amount: 32
+        amount: 8
       aether:
         material: GOLD_NUGGET
         amount: 168
@@ -6455,7 +6455,7 @@ recipes:
          - Compacted Item
       chicken:
         material: RAW_CHICKEN
-        amount: 160
+        amount: 50
       inksacs:
         material: INK_SACK
         amount: 64
@@ -6512,7 +6512,7 @@ recipes:
          - Compacted Item
       beef:
         material: RAW_BEEF
-        amount: 160
+        amount: 80
       clownfish:
         material: RAW_FISH
         amount: 3
@@ -6569,7 +6569,7 @@ recipes:
          - Compacted Item
       pork:
         material: PORK
-        amount: 160
+        amount: 40
       salmon:
         material: RAW_FISH
         amount: 19


### PR DESCRIPTION
Now I know the argument against doing this is that we should leave it until we fix the mob spawning/culling plugin so the original numbers will be possible. However, people will not be able to smoothly test the recipes in their current state and the only complaints will be for the meat. For the sake of good testing, I have reduced the cost according to feedback from a few players working on the recipes.