### PR TITLE
More balanced XP Material Costs

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -6246,7 +6246,7 @@ recipes:
     input:
       wheat:
         material: WHEAT
-        amount: 64
+        amount: 128
       logs:
         material: LOG
         amount: 128
@@ -6274,7 +6274,7 @@ recipes:
     input:
       carrots:
         material: CARROT_ITEM
-        amount: 64
+        amount: 128
       logs:
         material: LOG
         amount: 128
@@ -6302,7 +6302,7 @@ recipes:
     input:
       potatoes:
         material: POTATO_ITEM
-        amount: 64
+        amount: 128
       logs:
         material: LOG
         amount: 128
@@ -6331,7 +6331,7 @@ recipes:
     input:
       wheat:
         material: WHEAT
-        amount: 320
+        amount: 640
       acacialogs:
         material: LOG_2
         amount: 640
@@ -6365,7 +6365,7 @@ recipes:
     input:
       carrots:
         material: CARROT_ITEM
-        amount: 320
+        amount: 640
       sprucelogs:
         material: LOG
         amount: 640
@@ -6400,7 +6400,7 @@ recipes:
     input:
       potatoes:
         material: POTATO_ITEM
-        amount: 320
+        amount: 640
       birchlogs:
         material: LOG
         amount: 640
@@ -6440,14 +6440,14 @@ recipes:
          - Compacted Item
       acacialogs:
         material: LOG_2
-        amount: 50
+        amount: 18
         durability: 0
         lore:
          - Compacted Item
       junglesaplings:
         material: SAPLING
         amount: 4
-        durability: 3
+        durability: 1
         lore:
          - Compacted Item
       netherwart:
@@ -6468,9 +6468,7 @@ recipes:
         amount: 64
       apples:
         material: APPLE
-        amount: 1
-        lore:
-         - Compacted Item
+        amount: 32
       aether:
         material: GOLD_NUGGET
         amount: 960
@@ -6496,13 +6494,13 @@ recipes:
          - Compacted Item
       sprucelogs:
         material: LOG
-        amount: 50
+        amount: 24
         durability: 1
         lore:
          - Compacted Item
       darkoaksaplings:
         material: SAPLING
-        amount: 2
+        amount: 1
         durability: 5
         lore:
          - Compacted Item
@@ -6554,13 +6552,13 @@ recipes:
          - Compacted Item
       birchlogs:
         material: LOG
-        amount: 50
+        amount: 24
         durability: 2
         lore:
          - Compacted Item
       oaksaplings:
         material: SAPLING
-        amount: 6
+        amount: 3
         durability: 0
         lore:
          - Compacted Item


### PR DESCRIPTION
Currently, even though chopping trees is generally one of the nicer things to farm, it currently requires a huge amount of work needed in comparison to the other ingredients. Wheat can be broken/placed almost instantly, and can be placed next to each other, yet for some reason the recipes required about double the amount of logs - which cannot be broken so easily and must take up a huge amount of space in comparison to the other farms. It doesn't really matter too much if it's slightly off-balance (in terms of work done for each ingredient) but this is obnoxiously unbalanced in a way that farming-specialisation in SkillUp will not help with XP much as all of the user's time will be spend chopping wood!