### PR TITLE
Made Dowsing Factory upgradable

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -5353,7 +5353,7 @@ recipes:
         material: COMPASS
         amount: 1
       map:
-        material: MAP
+        material: EMPTY_MAP
         amount: 1
       xp:
         material: EMERALD_BLOCK

--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -5352,9 +5352,6 @@ recipes:
       compass:
         material: COMPASS
         amount: 1
-      map:
-        material: EMPTY_MAP
-        amount: 1
       xp:
         material: EMERALD_BLOCK
         amount: 128


### PR DESCRIPTION
Previously, a MAP had the durability of 0 which is impossible to get.