### PR TITLE
Adding Fletching Factory and Spectral Arrows. Also, issues

### DIFF
--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -553,6 +553,8 @@ factories:
     - Upgrade_to_Printing_Press
     - Upgrade_to_Basic_Pylon
     - Upgrade_to_Redstone_Factory_Basic
+    - Upgrade_to_Fletching_Factory
+    
   bastionfactory:
     type: FCCUPGRADE
     name: Bastion Factory
@@ -941,6 +943,12 @@ factories:
      - Enchant_Punch_I
      - Enchant_Punch_II
      - Repair_Factory
+  fletchingfactory:
+    type: FCCUPGRADE
+    name: Fletching Factory
+    recipes:
+     - Fletch_Spectral_Arrows
+     
 #Swords
   daggerforge:
     type: FCCUPGRADE
@@ -5388,7 +5396,43 @@ recipes:
       xp:
         material: EMERALD_BLOCK
         amount: 128
-        
+  Upgrade_to_Fletching_Factory:
+    production_time: 60m
+    type: UPGRADE
+    name: Upgrade to Fletching Factory
+    fuel_consumption_intervall: 50s
+    input:
+      arrowsfordays:
+        material: ARROW
+        amount: 512
+      eggsaresticky:
+        material: EGG
+        amount: 256
+      gluten:
+        material: HAY_BLOCK
+        amount: 128
+      netherwart:
+        material: NETHER_WARTS 
+        amount: 64
+      oaktreesapglue:
+         material: SAPLING
+         amount: 32
+         durability: 0
+      sprucesapglue:
+         material: SAPLING
+         amount: 32
+         durability: 1
+      water:
+        material: WATER_BUCKET 
+        amount: 4
+#May cause issues. Have we tried outputs with an upgrade recipe before?
+    output:
+      drybuckets:
+        material: BUCKET
+        amount: 4
+    factory: Fletching Factory
+
+
 #Pylon recipes
   Pylon_Basic:
     name: Extract Aether
@@ -10020,6 +10064,24 @@ recipes:
     enchant_item:
       armor:
         material: DIAMOND_SWORD
+        
+#Fletch Arrow recipes
+  Fletch_Spectral_Arrows:
+    name: Fletch Spectral Arrows
+    type: PRODUCTION
+    production_time: 30s
+    fuel_consumption_intervall: 5s
+    input:
+      arrows:
+        material: ARROW
+        amount: 16
+      glowdust:
+        material: GLOWSTONE_DUST
+        amount: 16
+    output:
+      arrowsS:
+        material: SPECTRAL_ARROW
+        amount: 64
         
 #Destroy factory and returns the setup cost multiplied by a given factor
   Return_Materials:

--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -5410,25 +5410,36 @@ recipes:
         amount: 256
       gluten:
         material: HAY_BLOCK
-        amount: 128
+        amount: 256
       netherwart:
         material: NETHER_WARTS 
-        amount: 64
+        amount: 256
       oaktreesapglue:
          material: SAPLING
-         amount: 32
+         amount: 64
          durability: 0
       sprucesapglue:
          material: SAPLING
-         amount: 32
+         amount: 64
          durability: 1
-      water:
+      birchsapglue:
+         material: SAPLING
+         amount: 64
+         durability: 2
+      acaciasapglue:
+         material: SAPLING
+         amount: 64
+         durability: 3
+      junglesapglue:
+         material: SAPLING
+         amount: 64
+         durability: 4
+      darkoaksapglue:
+         material: SAPLING
+         amount: 64
+         durability: 5
+      ripurwater:
         material: WATER_BUCKET 
-        amount: 4
-#May cause issues. Have we tried outputs with an upgrade recipe before?
-    output:
-      drybuckets:
-        material: BUCKET
         amount: 4
     factory: Fletching Factory
 

--- a/configCivcraft.yml
+++ b/configCivcraft.yml
@@ -948,6 +948,7 @@ factories:
     name: Fletching Factory
     recipes:
      - Fletch_Spectral_Arrows
+     - Fletch_Jump1_Arrows
      
 #Swords
   daggerforge:
@@ -5402,45 +5403,43 @@ recipes:
     name: Upgrade to Fletching Factory
     fuel_consumption_intervall: 50s
     input:
-      arrowsfordays:
-        material: ARROW
+      featherssfordays:
+        material: FEATHER 
+        amount: 256
+      flintpower:
+        material: FLINT
+        amount: 256
+      sap:
+        material: LOG
+        amount: 256
+        durability: -1
+      bows:
+        material: BOW
+        amount: 8
+      glowstone:
+        material: GLOWSTONE
         amount: 512
-      eggsaresticky:
-        material: EGG
+      redblock:
+        material: REDSTONE_BLOCK
+        amount: 64
+      blazerods:
+        material: BLAZE_ROD
         amount: 256
-      gluten:
-        material: HAY_BLOCK
+      magmacream:
+        material: MAGMA_CREAM
         amount: 256
-      netherwart:
-        material: NETHER_WARTS 
+      ghasttears:
+        material: GHAST_TEAR
+        amount: 64
+      sugar:
+        material: SUGAR
         amount: 256
-      oaktreesapglue:
-         material: SAPLING
-         amount: 64
-         durability: 0
-      sprucesapglue:
-         material: SAPLING
-         amount: 64
-         durability: 1
-      birchsapglue:
-         material: SAPLING
-         amount: 64
-         durability: 2
-      acaciasapglue:
-         material: SAPLING
-         amount: 64
-         durability: 3
-      junglesapglue:
-         material: SAPLING
-         amount: 64
-         durability: 4
-      darkoaksapglue:
-         material: SAPLING
-         amount: 64
-         durability: 5
+      sugareye:
+        material: FERMENTED_SPIDER_EYE
+        amount: 256
       ripurwater:
         material: WATER_BUCKET 
-        amount: 4
+        amount: 8
     factory: Fletching Factory
 
 
@@ -10093,7 +10092,31 @@ recipes:
       arrowsS:
         material: SPECTRAL_ARROW
         amount: 64
-        
+  Fletch_Jump1_Arrows:
+    name: Fletch Jump I Arrows
+    type: PRODUCTION
+    production_time: 30s
+    fuel_consumption_interval: 5s
+    input:
+      arrows:
+        material: ARROW
+        amount: 64
+      jumppot1:
+        material: POTION
+        amount: 8
+        potion_effects:
+          type: JUMP
+          upgrade: false
+          extended: false
+    output:
+      jumparrows1:
+        material: TIPPED_ARROW
+        amount: 64
+        potion_effects:
+          type: JUMP
+          upgrade: false
+          extended: false
+
 #Destroy factory and returns the setup cost multiplied by a given factor
   Return_Materials:
     type: COSTRETURN


### PR DESCRIPTION
Fletching factory added. To get it, you upgrade from a laboratory with 512 arrows, 256 eggs, 128 hay bales, 64 nether warts, 32 oak saplings, 32 spruce saplings, and 4 water buckets (which turn into buckets after running the factory). 

The reasoning behind this recipe is that these things all have sticky combinations, and nether wart is useful for potions anyway. Also, the materials come from different shards.

The Spectral Arrows come from inputting 16 arrows and 16 glowstone dust to create 64 spectral arrows. In vanilla minecraft, you can create 32 spectral arrows using just 16 arrows and a 64 glowstone dust. The factory recipe is more efficient by doubling output and cutting glowstone to a quarter of the cost. 

Now for the issues. There does not appear to be a way to create potion tipped arrows with factory mod. In fact, Factory Mod does not seem to recognize potions either. That means that inputs and outputs seem to not have a way to understand the input and the output. If durability can help the factory understand potions and potion tipped arrows (like it does with dyes and saplings) in the future (if not already done so), then we can make some work on the potion arrows.

(For later recipe reference, one lingering potion can create 8 potion arrows in vanilla Minecraft. I recommend that the factory produce more arrows than that. Like 16.)

Anyhow, this should be a good start for creating special arrows. Let us know how we can make the factories understand potion tipped arrows and potions and things can move forward.