### PR TITLE
Balanced Melon Cost for XP Recipes

### DIFF
--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -6936,7 +6936,7 @@ recipes:
         amount: 160
       melons:
         material: MELON_BLOCK
-        amount: 128
+        amount: 48
 #      chicken:
 #        material: RAW_CHICKEN
 #        amount: 32
@@ -7052,7 +7052,7 @@ recipes:
          - Compacted Item
       melons:
         material: MELON_BLOCK
-        amount: 10
+        amount: 4
         lore:
          - Compacted Item
 #      chicken:


### PR DESCRIPTION
Not quite sure how this managed to slip through unnoticed until now. My bad :/

Right now, if you have an adept transmuter and a single advanced pylon, then in order to keep up with aether production using the Lead Enrichment you would need to create a melon farm with 6,144 slots - which is 61 rows at a length of 100 each. This would only need to be harvested every 2 days, but it still looks like this:

https://i.gyazo.com/8420ff825df6c882a6e957504df9af14.jpg

That is 61 rows, each 100 long. Total of 6,100 which isn't even enough to cover the recipe.

This is with 1 Adept Transmuter and a single Advanced Pylon - which is 8 runs a day needed to keep up with aether production.

Now, the reason as to why this is currently in this state is down to a couple things:

- The rate at which the melon blocks grow is 48hrs in Jungle, which afaik is the quickest. Pumpkins take 24hrs in Spruce Forest afaik too, so they are a bit nicer.

- Clay only affects the stalk growth, meaning it cannot be sped up after this point.

- Silk Touch will not be commonly used until much much later in the game, meaning currently it takes 3x the melons harvested compared to pumpkins to get the blocks.

Soo yea right now it's a bit silly in regards to how much it outweighs the other ingredients. Wheat/potatoes/carrots takes just over 1k per day, which is a whole lot less than people did in 2.0. The logs are 10 stacks per day - nothing compared to those melons.

Bloody melons.