### PR TITLE
Added alternate upgrade to wood processor

### DIFF
--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -45,6 +45,7 @@ factories:
     - Upgrade_to_Blacksmith
     - Upgrade_to_Laboratory
     - Upgrade_to_Wood_Processor
+    - Upgrade_to_Wood_Processor_2
     - Upgrade_to_Basic_Forge
     - Upgrade_to_Basic_Fortification
     
@@ -5286,6 +5287,16 @@ recipes:
         durability: -1
         amount: 512
     factory: Wood Processor
+  Upgrade_to_Wood_Processor_2:
+    production_time: 10m
+    type: UPGRADE
+    name: Upgrade to Wood Processor with Dark Oak or Acacia
+    fuel_consumption_interval: 20s
+    input:
+      planks:
+        material: LOG2
+        durability: -1
+        amount: 512
   Upgrade_to_Wool_Processing:
     production_time: 1800s
     type: UPGRADE

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -5294,7 +5294,7 @@ recipes:
     fuel_consumption_interval: 20s
     input:
       planks:
-        material: LOG2
+        material: LOG_2
         durability: -1
         amount: 512
   Upgrade_to_Wool_Processing:


### PR DESCRIPTION
Currently because there's log and log2 you can't use dark oak or acacia to upgrade to a wood processor. Seeing as dark oak is the primary wood type in certain shards I think this is needed pending a change (possibly in CivModCore) to allow the log material with wildcard durability to allow for log2