### PR TITLE
Endgame EXP and pylon rebalancing

### DIFF
--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -7250,7 +7250,7 @@ recipes:
          - Compacted Item
       oaksaplings:
         material: SAPLING
-        amount: 2
+        amount: 1
         durability: 0
         lore:
          - Compacted Item
@@ -7269,7 +7269,7 @@ recipes:
 #        amount: 160
       salmon:
         material: RAW_FISH
-        amount: 19
+        amount: 5
         durability: 1
       vines:
         material: VINE

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -5652,7 +5652,7 @@ recipes:
     name: Extract Aether
     type: PYLON
     production_time: 4h
-    fuel_consumption_intervall: 80m
+    fuel_consumption_intervall: 24m
     input:
     output:
       aether:
@@ -5667,7 +5667,7 @@ recipes:
   Pylon_Advanced:
     name: Extract Aether
     type: PYLON
-    fuel_consumption_intervall: 80m
+    fuel_consumption_intervall: 24m
     production_time: 2h
     input:
     output:
@@ -5683,7 +5683,7 @@ recipes:
   Pylon_Expert:
     name: Extract Aether
     type: PYLON
-    fuel_consumption_intervall: 80m
+    fuel_consumption_intervall: 24m
     production_time: 2h
     input:
     output:

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -7194,7 +7194,7 @@ recipes:
          - Compacted Item
       darkoaksaplings:
         material: SAPLING
-        amount: 32
+        amount: 16
         durability: 5
       cactus:
         material: CACTUS
@@ -7216,7 +7216,7 @@ recipes:
         durability: 3
       eggs:
         material: EGG
-        amount: 8
+        amount: 4
         lore:
          - Compacted Item
       aether:

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -7213,7 +7213,7 @@ recipes:
 #      beef:
 #        material: RAW_BEEF
 #        amount: 160
-      clownfish:
+      pufferfish:
         material: RAW_FISH
         amount: 3
         durability: 3

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -7157,12 +7157,15 @@ recipes:
 #      chicken:
 #        material: RAW_CHICKEN
 #        amount: 160
-      inksacs:
-        material: INK_SACK
-        amount: 32
-      apples:
-        material: APPLE
-        amount: 16
+      vines:
+        material: VINE
+        amount: 6
+        lore:
+         - Compacted Item
+      fish:
+        material: RAW_FISH
+        amount: 15
+        durability: 1
       aether:
         material: GOLD_NUGGET
         amount: 120
@@ -7214,9 +7217,9 @@ recipes:
         material: RAW_FISH
         amount: 3
         durability: 3
-      eggs:
-        material: EGG
-        amount: 4
+      vines:
+        material: VINE
+        amount: 6
         lore:
          - Compacted Item
       aether:

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -5652,7 +5652,7 @@ recipes:
     name: Extract Aether
     type: PYLON
     production_time: 4h
-    fuel_consumption_intervall: 6m
+    fuel_consumption_intervall: 80m
     input:
     output:
       aether:
@@ -5667,7 +5667,7 @@ recipes:
   Pylon_Advanced:
     name: Extract Aether
     type: PYLON
-    fuel_consumption_intervall: 6m
+    fuel_consumption_intervall: 80m
     production_time: 2h
     input:
     output:
@@ -5683,7 +5683,7 @@ recipes:
   Pylon_Expert:
     name: Extract Aether
     type: PYLON
-    fuel_consumption_intervall: 6m
+    fuel_consumption_intervall: 80m
     production_time: 2h
     input:
     output:

--- a/src/main/resources/configCivcraft.yml
+++ b/src/main/resources/configCivcraft.yml
@@ -7140,7 +7140,7 @@ recipes:
          - Compacted Item
       junglesaplings:
         material: SAPLING
-        amount: 2
+        amount: 1
         durability: 3
         lore:
          - Compacted Item
@@ -7159,10 +7159,10 @@ recipes:
 #        amount: 160
       inksacs:
         material: INK_SACK
-        amount: 64
+        amount: 32
       apples:
         material: APPLE
-        amount: 32
+        amount: 16
       aether:
         material: GOLD_NUGGET
         amount: 120


### PR DESCRIPTION
Pylons and endgame transmuters need to feel like a reward after all that grinding. I've changed the pylons to run for a week on 2 stacks of coal.

I've also made tweaks to the grandmaster transmuter recipes best I could. I only have data on the Ruby one though. I' ve tried to be fair about it, but our town doesn't run the others. My main point is that sapplings are way to hard to get in such large quantities, fish for ruby is out of whack in comparison to the topaz recipe and eggs are way to hard to get 8 stacks of.

The Amethys recipe needs to be changed as I dont see anyone going that route.